### PR TITLE
Days are now sorted before handing to the FE

### DIFF
--- a/lib/orderEventsByDay.js
+++ b/lib/orderEventsByDay.js
@@ -1,11 +1,17 @@
 module.exports = function orderEventsByDay(events) {
-  const days = {};
+  const unorderedDaysAndEvents = {};
   events.forEach(event => {
     const day = new Intl.DateTimeFormat(
       'en-US',
       { timeZone: 'America/Denver' },
     ).format(new Date(event.start));
-    days[day] = days[day] ? days[day].concat(event) : [event];
+    unorderedDaysAndEvents[day] = unorderedDaysAndEvents[day] ? unorderedDaysAndEvents[day].concat(event) : [event];
   });
-  return days;
+
+  const days = Object.keys(unorderedDaysAndEvents)
+  const orderedDaysAndEvents = {};
+  days.sort().forEach(day=> {
+    orderedDaysAndEvents[day] = unorderedDaysAndEvents[day]
+  })
+  return orderedDaysAndEvents;
 };


### PR DESCRIPTION
### How does this get shipped to prod?

Push to Heroku, ensure dates are ordered

### What does this PR do?

Orders the dates on the root page

### Screenshots or gifs of the new hotness

The Oldes:
<img width="1040" alt="Screen Shot 2020-08-20 at 11 49 25 AM" src="https://user-images.githubusercontent.com/6353499/90807241-68ab6680-e2db-11ea-93a6-7c3a02d58b9d.png">

The Newes:
<img width="1094" alt="Screen Shot 2020-08-20 at 11 49 33 AM" src="https://user-images.githubusercontent.com/6353499/90807268-752fbf00-e2db-11ea-8a17-fd476ae10c88.png">


### How do I verify?

Check order of dates

### ~Any new dependencies?~

### gif

![](https://media.giphy.com/media/LfCt1sR1VweBy/giphy.gif)
